### PR TITLE
fix(utils): add null check for utf16_string length calculation

### DIFF
--- a/windows/runner/utils.cpp
+++ b/windows/runner/utils.cpp
@@ -49,6 +49,9 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
       -1, nullptr, 0, nullptr, nullptr)
     -1; // remove the trailing null character
+  if (utf16_string == nullptr) {
+    return std::string();
+  }
   int input_length = (int)wcslen(utf16_string);
   std::string utf8_string;
   if (target_length == 0 || target_length > utf8_string.max_size()) {


### PR DESCRIPTION
## Summary
Added a null check before calculating the length of utf16_string to prevent potential undefined behavior.

## Changes
- Added early return if utf16_string is null before length calculation