### PR TITLE
refactor(database): replace deprecated declarative_base import

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -2,8 +2,8 @@
 Database models and ORM configuration using SQLAlchemy
 """
 from sqlalchemy import create_engine, Column, Integer, String, DateTime, Text, Boolean
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+# Updated import to use the modern location for declarative_base (SQLAlchemy 2.0+)
+from sqlalchemy.orm import declarative_base, sessionmaker
 from datetime import datetime
 import os
 from dotenv import load_dotenv


### PR DESCRIPTION
## Summary
Replaced the deprecated `sqlalchemy.ext.declarative.declarative_base` import with the modern `sqlalchemy.orm.declarative_base` to align with SQLAlchemy 2.0 recommendations.

## Implementation Details
- Updated the import statement to pull `declarative_base` from `sqlalchemy.orm`.
- Added a short comment explaining the change and its compatibility benefits.
- No functional changes to the ORM models or database behavior; the `Base` class remains identical.

## Risk Assessment
The change only affects the import path of a function that provides the same API. It does not alter any runtime logic, model definitions, or database interactions, making it a low‑risk, backward‑compatible improvement.