### PR TITLE
refactor(com): ensure COM is uninitialized via RAII

### DIFF
--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -14,8 +14,13 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   }
 
   // Initialize COM, so that it is available for use in the library and/or
-  // plugins.
-  ::CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+  // plugins. Use RAII to guarantee uninitialization.
+  struct ComInitializer {
+    ComInitializer() {
+      ::CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+    }
+    ~ComInitializer() { ::CoUninitialize(); }
+  } com_init;
 
   flutter::DartProject project(L"data");
 
@@ -38,6 +43,5 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
     ::DispatchMessage(&msg);
   }
 
-  ::CoUninitialize();
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Summary
Introduce an RAII helper to manage COM initialization and uninitialization, guaranteeing that `CoUninitialize` is called even if the function exits early due to errors.

## Implementation Details
- Added a local `ComInitializer` struct with a constructor that calls `CoInitializeEx` and a destructor that calls `CoUninitialize`.
- Replaced the direct calls to `CoInitializeEx` and `CoUninitialize` with an instance of `ComInitializer`.
- This change does not alter any functional behavior but improves resource safety and code readability.

## Risk Assessment
The modification only encapsulates existing COM calls; the semantics remain identical. No API changes or logic alterations are introduced, making this a low‑risk improvement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal resource management to enhance application stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->